### PR TITLE
Implement app theme

### DIFF
--- a/lib/config/app_theme.dart
+++ b/lib/config/app_theme.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'global_color.dart';
+
+class AppTheme {
+  static const Color neonBlue = Color(0xFF00C4FF);
+  static const double defaultRadius = 12;
+
+  static ThemeData get lightTheme {
+    final base = ThemeData(
+      useMaterial3: true,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: neonBlue,
+        brightness: Brightness.light,
+      ),
+    );
+    return base.copyWith(
+      cardTheme: CardTheme(
+        color: GlobalColors.cardLightBg,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(defaultRadius),
+        ),
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: base.colorScheme.primary,
+        foregroundColor: base.colorScheme.onPrimary,
+        centerTitle: true,
+        elevation: 0,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: base.colorScheme.primary,
+          foregroundColor: base.colorScheme.onPrimary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(defaultRadius),
+          ),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: GlobalColors.inputLightFill,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(defaultRadius),
+        ),
+      ),
+      textTheme: GoogleFonts.orbitronTextTheme(base.textTheme),
+    );
+  }
+
+  static ThemeData get darkTheme {
+    final base = ThemeData(
+      useMaterial3: true,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: neonBlue,
+        brightness: Brightness.dark,
+      ),
+    );
+    return base.copyWith(
+      cardTheme: CardTheme(
+        color: GlobalColors.cardDarkBg,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(defaultRadius),
+        ),
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: base.colorScheme.primary,
+        foregroundColor: base.colorScheme.onPrimary,
+        centerTitle: true,
+        elevation: 0,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: base.colorScheme.primary,
+          foregroundColor: base.colorScheme.onPrimary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(defaultRadius),
+          ),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: GlobalColors.inputDarkFill,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(defaultRadius),
+        ),
+      ),
+      textTheme: GoogleFonts.orbitronTextTheme(base.textTheme),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
 import 'package:get_storage/get_storage.dart';
-import 'package:smart_factory/config/global_color.dart';
+import 'package:smart_factory/config/app_theme.dart';
 import 'package:smart_factory/screen/login/controller/login_controller.dart';
 import 'package:smart_factory/screen/login/controller/user_profile_manager.dart';
 import 'package:smart_factory/screen/navbar/controller/navbar_controller.dart';
@@ -49,22 +49,8 @@ class MyApp extends StatelessWidget {
           () => GetMaterialApp(
         debugShowCheckedModeBanner: false,
         themeMode: settingController.isDarkMode.value ? ThemeMode.dark : ThemeMode.light,
-        theme: ThemeData.light().copyWith(
-          elevatedButtonTheme: ElevatedButtonThemeData(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: GlobalColors.primaryButtonLight,
-              foregroundColor: Colors.white,
-            ),
-          ),
-        ),
-        darkTheme: ThemeData.dark().copyWith(
-          elevatedButtonTheme: ElevatedButtonThemeData(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: GlobalColors.primaryButtonDark,
-              foregroundColor: Colors.white,
-            ),
-          ),
-        ),
+        theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
         locale: languageController.currentLocale.value,
         localeResolutionCallback: (locale, supportedLocales) {
           return supportedLocales.contains(locale) ? locale : const Locale('vi');
@@ -85,5 +71,4 @@ class MyApp extends StatelessWidget {
         ],
       ),
     );
-  }
-}
+  }}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   intl: ^0.19.0
   smooth_page_indicator: ^1.1.0
   local_auth: ^2.2.0
+  google_fonts: ^6.1.0
 
 
 icons_launcher:


### PR DESCRIPTION
## Summary
- add `AppTheme` with light and dark themes
- wire up new theme in `main.dart`
- include `google_fonts` dependency for Orbitron text theme

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e0bcd2c88832596fc1294f72ebab6