### PR TITLE
Refine PTH dashboard UI

### DIFF
--- a/lib/screen/home/widget/pth_dashboard_filter_panel.dart
+++ b/lib/screen/home/widget/pth_dashboard_filter_panel.dart
@@ -310,6 +310,5 @@ class _PTHDashboardFilterPanelState extends State<PTHDashboardFilterPanel> with 
         ),
       ),
     );
-    );
   }
 }

--- a/lib/screen/home/widget/pth_dashboard_machine_detail.dart
+++ b/lib/screen/home/widget/pth_dashboard_machine_detail.dart
@@ -13,7 +13,15 @@ class PTHDashboardMachineDetail extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     if (machines.isEmpty) {
-      return const SizedBox();
+      return Card(
+        color: isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg,
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: const SizedBox(
+          height: 100,
+          child: Center(child: Text('No data available')),
+        ),
+      );
     }
 
     return DefaultTabController(

--- a/lib/screen/home/widget/pth_dashboard_output_chart.dart
+++ b/lib/screen/home/widget/pth_dashboard_output_chart.dart
@@ -9,10 +9,19 @@ class PTHDashboardOutputChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final output = data['output'] as List? ?? [];
-    if (output.isEmpty) {
-      return const Text("Không có dữ liệu output.");
-    }
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    if (output.isEmpty) {
+      return Card(
+        color: isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg,
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: const SizedBox(
+          height: 210,
+          child: Center(child: Text('No data available')),
+        ),
+      );
+    }
+
     final labelColor =
         isDark ? GlobalColors.labelDark : GlobalColors.labelLight;
 

--- a/lib/screen/home/widget/pth_dashboard_runtime_chart.dart
+++ b/lib/screen/home/widget/pth_dashboard_runtime_chart.dart
@@ -15,7 +15,15 @@ class PTHDashboardRuntimeChart extends StatelessWidget {
         isDark ? GlobalColors.labelDark : GlobalColors.labelLight;
 
     if (machines.isEmpty) {
-      return const Text("Không có dữ liệu runtime máy.");
+      return Card(
+        color: isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg,
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: const SizedBox(
+          height: 220,
+          child: Center(child: Text('No data available')),
+        ),
+      );
     }
 
     // Lấy tất cả giờ xuất hiện trong data (trục X)

--- a/lib/screen/home/widget/pth_dashboard_screen.dart
+++ b/lib/screen/home/widget/pth_dashboard_screen.dart
@@ -151,9 +151,6 @@ class _PTHDashboardScreenState extends State<PTHDashboardScreen> with TickerProv
                     ],
                   ),
                 ),
-                // Loading indicator
-                if (controller.isLoading.value)
-                  const LinearProgressIndicator(minHeight: 3),
                 // Nội dung dashboard
                 Expanded(
                   child: ListView(
@@ -183,6 +180,13 @@ class _PTHDashboardScreenState extends State<PTHDashboardScreen> with TickerProv
             closeFilter();
           },
         ),
+        // Loading overlay
+        Obx(() => controller.isLoading.value
+            ? Container(
+                color: Colors.black.withOpacity(0.3),
+                child: const Center(child: CircularProgressIndicator()),
+              )
+            : const SizedBox.shrink()),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- add semi-transparent loading overlay for PTH dashboard
- show a card with "No data available" when charts or machine details are empty
- tidy filter panel closing widgets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68770021676c832580982f1495d2cd07