### PR TITLE
Add racks monitor screen

### DIFF
--- a/lib/routes/screen_factory.dart
+++ b/lib/routes/screen_factory.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:smart_factory/screen/home/widget/aoivi/avi_dashboard_screen.dart';
+import 'package:smart_factory/screen/home/widget/racks_monitor/racks_monitor_screen.dart';
 
 import '../model/AppModel.dart';
 import '../screen/home/widget/project_list_page.dart';
 
 final Map<String, Widget Function(AppProject)> screenBuilderMap = {
   'pth_dashboard': (project) => AOIVIDashboardScreen(),
+  'racks_monitor': (project) => RacksMonitorScreen(project: project),
 };
 /// Hàm trả về đúng màn hình dựa trên AppProject
 Widget buildProjectScreen(AppProject project) {

--- a/lib/screen/home/controller/racks_monitor_controller.dart
+++ b/lib/screen/home/controller/racks_monitor_controller.dart
@@ -1,0 +1,32 @@
+import 'package:get/get.dart';
+import '../../../service/lc_switch_rack_api.dart';
+
+class RacksMonitorController extends GetxController {
+  var racks = <Map<String, dynamic>>[].obs;
+  var isLoading = false.obs;
+  var error = ''.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadRacks();
+  }
+
+  Future<void> loadRacks() async {
+    try {
+      isLoading.value = true;
+      error.value = '';
+      final data = await LCSwitchRackApi.getRackMonitoring();
+      final list = data['Data']?['RackDetails'];
+      if (list is List) {
+        racks.value = List<Map<String, dynamic>>.from(list);
+      } else {
+        racks.value = [];
+      }
+    } catch (e) {
+      error.value = e.toString();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/screen/home/widget/racks_monitor/racks_monitor_screen.dart
+++ b/lib/screen/home/widget/racks_monitor/racks_monitor_screen.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../../config/global_color.dart';
+import '../../../../config/global_text_style.dart';
+import '../../../../model/AppModel.dart';
+import '../../controller/racks_monitor_controller.dart';
+
+class RacksMonitorScreen extends StatelessWidget {
+  final AppProject project;
+  const RacksMonitorScreen({super.key, required this.project});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(RacksMonitorController());
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Scaffold(
+      backgroundColor:
+          isDark ? GlobalColors.bodyDarkBg : GlobalColors.bodyLightBg,
+      appBar: AppBar(
+        title: Text(
+          project.name,
+          style: GlobalTextStyles.bodyLarge(isDark: isDark).copyWith(
+            color: isDark
+                ? GlobalColors.appBarDarkText
+                : GlobalColors.appBarLightText,
+          ),
+        ),
+        backgroundColor:
+            isDark ? GlobalColors.appBarDarkBg : GlobalColors.appBarLightBg,
+        iconTheme: IconThemeData(
+          color:
+              isDark ? GlobalColors.appBarDarkText : GlobalColors.appBarLightText,
+        ),
+        elevation: 0,
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.error.value.isNotEmpty) {
+          return Center(child: Text(controller.error.value));
+        }
+        final racks = controller.racks;
+        if (racks.isEmpty) {
+          return const Center(child: Text('No data'));
+        }
+        return RefreshIndicator(
+          onRefresh: controller.loadRacks,
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: racks.length,
+            itemBuilder: (context, idx) {
+              final rack = racks[idx];
+              final slots = (rack['SlotDetails'] as List?) ?? [];
+              final totalPass = rack['Total_Pass'] ?? 0;
+              final yr = rack['YR'] ?? 0;
+              return Card(
+                margin:
+                    const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        rack['RackName']?.toString() ?? 'Rack',
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 16),
+                      ),
+                      const SizedBox(height: 6),
+                      Text('Pass: $totalPass | YR: $yr%'),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 4,
+                        runSpacing: 4,
+                        children: List.generate(slots.length, (i) {
+                          final slot = slots[i] as Map? ?? {};
+                          final status = slot['Status']?.toString() ?? '';
+                          final slotName = slot['SlotName'] ?? '';
+                          final slotPass = slot['Total_Pass'] ?? 0;
+                          final slotFail = slot['Fail'] ?? 0;
+                          final slotYr = slot['YR'] ?? 0;
+                          Color color;
+                          if (status == 'Pass') {
+                            color = Colors.green;
+                          } else if (status == 'Fail') {
+                            color = Colors.red;
+                          } else {
+                            color = Colors.blueGrey;
+                          }
+                          return Container(
+                            padding: const EdgeInsets.all(4),
+                            decoration: BoxDecoration(
+                              border: Border.all(color: color),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text('Slot $slotName',
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.w500)),
+                                Text('$slotPass/${slotPass + slotFail}'),
+                                Text('$slotYr%'),
+                              ],
+                            ),
+                          );
+                        }),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/service/lc_switch_rack_api.dart
+++ b/lib/service/lc_switch_rack_api.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'auth/auth_config.dart';
+
+class LCSwitchRackApi {
+  static const String _url =
+      'https://10.220.130.117/NVIDIA/NvidiaLayout/GroupDataMonitoring';
+
+  static Future<Map<String, dynamic>> getRackMonitoring({
+    String modelSerial = 'SWITCH',
+    String groupName = 'J_TAG',
+    String nickName = 'GB300',
+  }) async {
+    final body = json.encode({
+      'ModelSerial': modelSerial,
+      'GroupName': groupName,
+      'NickName': nickName,
+    });
+
+    final res = await http.post(
+      Uri.parse(_url),
+      headers: AuthConfig.getAuthorizedHeaders(),
+      body: body,
+    );
+
+    if (res.statusCode == 200 && res.body.isNotEmpty) {
+      return json.decode(res.body) as Map<String, dynamic>;
+    } else if (res.statusCode == 204) {
+      return {};
+    } else {
+      throw Exception(
+          'Failed to load rack monitoring data (${res.statusCode})');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- map new `racks_monitor` route
- implement `LCSwitchRackApi` to call rack data
- add `RacksMonitorController`
- create `RacksMonitorScreen` with basic rack/slot list UI

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687daa4087a88325b95388aebb2eb2ff