### PR TITLE
Improve rack monitor UI

### DIFF
--- a/lib/screen/home/widget/racks_monitor/racks_monitor_screen.dart
+++ b/lib/screen/home/widget/racks_monitor/racks_monitor_screen.dart
@@ -9,6 +9,14 @@ class RacksMonitorScreen extends StatelessWidget {
   final AppProject project;
   const RacksMonitorScreen({super.key, required this.project});
 
+  Color _statusColor(num value) {
+    if (value is num) {
+      if (value > 50) return Colors.green;
+      if (value > 30) return Colors.orange;
+    }
+    return Colors.red;
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = Get.put(RacksMonitorController());
@@ -47,8 +55,14 @@ class RacksMonitorScreen extends StatelessWidget {
         }
         return RefreshIndicator(
           onRefresh: controller.loadRacks,
-          child: ListView.builder(
-            padding: const EdgeInsets.symmetric(vertical: 8),
+          child: GridView.builder(
+            padding: const EdgeInsets.all(12),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: MediaQuery.of(context).size.width > 600 ? 3 : 2,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 1.2,
+            ),
             itemCount: racks.length,
             itemBuilder: (context, idx) {
               final rack = racks[idx];
@@ -56,57 +70,89 @@ class RacksMonitorScreen extends StatelessWidget {
               final totalPass = rack['Total_Pass'] ?? 0;
               final yr = rack['YR'] ?? 0;
               return Card(
-                margin:
-                    const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+                color: isDark
+                    ? GlobalColors.cardDarkBg
+                    : GlobalColors.cardLightBg,
                 child: Padding(
-                  padding: const EdgeInsets.all(12),
+                  padding: const EdgeInsets.all(8),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
                         rack['RackName']?.toString() ?? 'Rack',
                         style: const TextStyle(
-                            fontWeight: FontWeight.bold, fontSize: 16),
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                      const SizedBox(height: 6),
+                      const SizedBox(height: 4),
                       Text('Pass: $totalPass | YR: $yr%'),
+                      const SizedBox(height: 4),
+                      LinearProgressIndicator(
+                        value: (yr is num ? yr.clamp(0, 100) : 0) / 100,
+                        minHeight: 6,
+                        backgroundColor:
+                            isDark ? Colors.white12 : Colors.grey.shade300,
+                        valueColor:
+                            AlwaysStoppedAnimation<Color>(_statusColor(yr)),
+                      ),
                       const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 4,
-                        runSpacing: 4,
-                        children: List.generate(slots.length, (i) {
-                          final slot = slots[i] as Map? ?? {};
-                          final status = slot['Status']?.toString() ?? '';
-                          final slotName = slot['SlotName'] ?? '';
-                          final slotPass = slot['Total_Pass'] ?? 0;
-                          final slotFail = slot['Fail'] ?? 0;
-                          final slotYr = slot['YR'] ?? 0;
-                          Color color;
-                          if (status == 'Pass') {
-                            color = Colors.green;
-                          } else if (status == 'Fail') {
-                            color = Colors.red;
-                          } else {
-                            color = Colors.blueGrey;
-                          }
-                          return Container(
-                            padding: const EdgeInsets.all(4),
-                            decoration: BoxDecoration(
-                              border: Border.all(color: color),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text('Slot $slotName',
-                                    style: const TextStyle(
-                                        fontWeight: FontWeight.w500)),
-                                Text('$slotPass/${slotPass + slotFail}'),
-                                Text('$slotYr%'),
-                              ],
-                            ),
-                          );
-                        }),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          child: Wrap(
+                            spacing: 4,
+                            runSpacing: 4,
+                            children: List.generate(slots.length, (i) {
+                              final slot = slots[i] as Map? ?? {};
+                              final slotName = slot['SlotName'] ?? '';
+                              final slotPass = slot['Total_Pass'] ?? 0;
+                              final slotFail = slot['Fail'] ?? 0;
+                              final slotYr = slot['YR'] ?? 0;
+                              return Container(
+                                width: 80,
+                                padding: const EdgeInsets.all(4),
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(4),
+                                  border:
+                                      Border.all(color: _statusColor(slotYr)),
+                                ),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Text(
+                                      'Slot $slotName',
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.w500,
+                                        fontSize: 12,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    LinearProgressIndicator(
+                                      value: (slotYr is num
+                                              ? slotYr.clamp(0, 100)
+                                              : 0) /
+                                          100,
+                                      minHeight: 4,
+                                      backgroundColor: isDark
+                                          ? Colors.white12
+                                          : Colors.grey.shade300,
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                          _statusColor(slotYr)),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      '$slotPass/${slotPass + slotFail}',
+                                      style: const TextStyle(fontSize: 11),
+                                    ),
+                                    Text(
+                                      '${slotYr.toString()}%',
+                                      style: const TextStyle(fontSize: 11),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            }),
+                          ),
+                        ),
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- update rack monitor screen to show racks in a grid
- add yield progress indicators and colored statuses

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687dadad19a88325a8b308d5c8d71675