### PR TITLE
Add yield report dashboard

### DIFF
--- a/lib/routes/screen_factory.dart
+++ b/lib/routes/screen_factory.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:smart_factory/screen/home/widget/aoivi/avi_dashboard_screen.dart';
 import 'package:smart_factory/screen/home/widget/racks_monitor/racks_monitor_screen.dart';
+import 'package:smart_factory/screen/home/widget/yield_report/yield_report_screen.dart';
 
 import '../model/AppModel.dart';
 import '../screen/home/widget/project_list_page.dart';
@@ -8,6 +9,7 @@ import '../screen/home/widget/project_list_page.dart';
 final Map<String, Widget Function(AppProject)> screenBuilderMap = {
   'pth_dashboard': (project) => AOIVIDashboardScreen(),
   'racks_monitor': (project) => RacksMonitorScreen(project: project),
+  'yield_report': (project) => const YieldReportScreen(),
 };
 /// Hàm trả về đúng màn hình dựa trên AppProject
 Widget buildProjectScreen(AppProject project) {

--- a/lib/screen/home/controller/yield_report_controller.dart
+++ b/lib/screen/home/controller/yield_report_controller.dart
@@ -1,0 +1,40 @@
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import '../../../service/yield_rate_api.dart';
+
+class YieldReportController extends GetxController {
+  var dates = <String>[].obs;
+  var dataNickNames = <Map<String, dynamic>>[].obs;
+  var isLoading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    fetchReport();
+  }
+
+  String _defaultRange() {
+    final now = DateTime.now();
+    final df = DateFormat('yyyy/MM/dd');
+    final start = df.format(now.subtract(const Duration(days: 2)));
+    final end = df.format(now);
+    return '$start 07:30 - $end 19:30';
+  }
+
+  Future<void> fetchReport({String? rangeDateTime, String nickName = 'All'}) async {
+    isLoading.value = true;
+    try {
+      final data = await YieldRateApi.getOutputReport(
+        rangeDateTime: rangeDateTime ?? _defaultRange(),
+        nickName: nickName,
+      );
+      final res = data['Data'] ?? {};
+      dates.value = List<String>.from(res['ClassDates'] ?? []);
+      dataNickNames.value = List<Map<String, dynamic>>.from(res['DataNickNames'] ?? []);
+    } catch (e) {
+      Get.snackbar('Error', e.toString());
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/screen/home/widget/yield_report/yield_report_screen.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../../config/global_color.dart';
+import '../../controller/yield_report_controller.dart';
+
+class YieldReportScreen extends StatelessWidget {
+  const YieldReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(YieldReportController());
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg;
+
+    return Obx(() => Scaffold(
+          appBar: AppBar(
+            title: const Text('Yield Rate Report'),
+            centerTitle: true,
+          ),
+          body: controller.isLoading.value
+              ? const Center(child: CircularProgressIndicator())
+              : ListView.builder(
+                  padding: const EdgeInsets.all(12),
+                  itemCount: controller.dataNickNames.length,
+                  itemBuilder: (context, idx) {
+                    final nick = controller.dataNickNames[idx];
+                    final models = nick['DataModelNames'] as List? ?? [];
+                    return Card(
+                      color: bgColor,
+                      child: ExpansionTile(
+                        title: Text(nick['NickName'] ?? ''),
+                        children: models.map<Widget>((m) {
+                          final stations = m['DataStations'] as List? ?? [];
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 8),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(m['ModelName'] ?? '',
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.bold)),
+                                const SizedBox(height: 6),
+                                SingleChildScrollView(
+                                  scrollDirection: Axis.horizontal,
+                                  child: DataTable(
+                                    columns: [
+                                      const DataColumn(label: Text('Station')),
+                                      ...controller.dates
+                                          .map((d) => DataColumn(label: Text(d)))
+                                          .toList(),
+                                    ],
+                                    rows: stations.map<DataRow>((st) {
+                                      final values = (st['Data'] as List? ?? [])
+                                          .map((e) => e.toString())
+                                          .toList();
+                                      return DataRow(cells: [
+                                        DataCell(Text(st['Station'] ?? '')),
+                                        ...values
+                                            .map((v) => DataCell(Text(v)))
+                                            .toList(),
+                                      ]);
+                                    }).toList(),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    );
+                  },
+                ),
+        ));
+  }
+}

--- a/lib/service/yield_rate_api.dart
+++ b/lib/service/yield_rate_api.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'auth/auth_config.dart';
+
+class YieldRateApi {
+  static const String _url =
+      'https://10.220.130.117/NVIDIA/YieldRate/PostOutputReport';
+
+  static Future<Map<String, dynamic>> getOutputReport({
+    String customer = 'NVIDIA',
+    String type = 'SWITCH',
+    required String rangeDateTime,
+    String nickName = 'All',
+  }) async {
+    final body = json.encode({
+      'Customer': customer,
+      'Type': type,
+      'RangeDateTime': rangeDateTime,
+      'NickName': nickName,
+    });
+
+    final res = await http.post(
+      Uri.parse(_url),
+      headers: AuthConfig.getAuthorizedHeaders(),
+      body: body,
+    );
+
+    if (res.statusCode == 200 && res.body.isNotEmpty) {
+      return json.decode(res.body) as Map<String, dynamic>;
+    } else if (res.statusCode == 204) {
+      return {};
+    } else {
+      throw Exception('Failed to load output report (${res.statusCode})');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `YieldRateApi` service to fetch yield rate data
- add `YieldReportController` to manage output report state
- implement `YieldReportScreen` with expandable tables
- wire new screen in `screen_factory`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881adb76510832586a353a53c1d44f3