### PR TITLE
Add yield report time filter

### DIFF
--- a/lib/routes/screen_factory.dart
+++ b/lib/routes/screen_factory.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:smart_factory/screen/home/widget/aoivi/avi_dashboard_screen.dart';
 import 'package:smart_factory/screen/home/widget/racks_monitor/racks_monitor_screen.dart';
+import 'package:smart_factory/screen/home/widget/yield_report/yield_report_screen.dart';
 
 import '../model/AppModel.dart';
 import '../screen/home/widget/project_list_page.dart';
@@ -8,6 +9,7 @@ import '../screen/home/widget/project_list_page.dart';
 final Map<String, Widget Function(AppProject)> screenBuilderMap = {
   'pth_dashboard': (project) => AOIVIDashboardScreen(),
   'racks_monitor': (project) => RacksMonitorScreen(project: project),
+  'yield_report': (project) => const YieldReportScreen(),
 };
 /// Hàm trả về đúng màn hình dựa trên AppProject
 Widget buildProjectScreen(AppProject project) {

--- a/lib/screen/home/controller/yield_report_controller.dart
+++ b/lib/screen/home/controller/yield_report_controller.dart
@@ -1,0 +1,50 @@
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import '../../../service/yield_rate_api.dart';
+
+class YieldReportController extends GetxController {
+  var dates = <String>[].obs;
+  var dataNickNames = <Map<String, dynamic>>[].obs;
+  var isLoading = false.obs;
+
+  late Rx<DateTime> startDateTime;
+  late Rx<DateTime> endDateTime;
+
+  final DateFormat _format = DateFormat('yyyy/MM/dd HH:mm');
+
+  @override
+  void onInit() {
+    super.onInit();
+    final now = DateTime.now();
+    startDateTime = Rx<DateTime>(
+      DateTime(now.year, now.month, now.day - 2, 7, 30),
+    );
+    endDateTime = Rx<DateTime>(
+      DateTime(now.year, now.month, now.day, 19, 30),
+    );
+    fetchReport();
+  }
+
+  String get range => '${_format.format(startDateTime.value)} - ${_format.format(endDateTime.value)}';
+
+  Future<void> fetchReport({String nickName = 'All'}) async {
+    isLoading.value = true;
+    try {
+      final data = await YieldRateApi.getOutputReport(
+        rangeDateTime: range,
+        nickName: nickName,
+      );
+      final res = data['Data'] ?? {};
+      dates.value = List<String>.from(res['ClassDates'] ?? []);
+      dataNickNames.value =
+          List<Map<String, dynamic>>.from(res['DataNickNames'] ?? []);
+    } catch (e) {
+      Get.snackbar('Error', e.toString());
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  void updateStart(DateTime dt) => startDateTime.value = dt;
+  void updateEnd(DateTime dt) => endDateTime.value = dt;
+}

--- a/lib/screen/home/widget/yield_report/yield_report_screen.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_screen.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import '../../../../config/global_color.dart';
+import '../../controller/yield_report_controller.dart';
+
+class YieldReportScreen extends StatelessWidget {
+  const YieldReportScreen({super.key});
+
+  Future<DateTime?> _pickDateTime(BuildContext context, DateTime initial) async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(initial.year - 1),
+      lastDate: DateTime(initial.year + 1),
+    );
+    if (date == null) return null;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initial),
+    );
+    if (time == null) return null;
+    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(YieldReportController());
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bgColor = isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg;
+
+    return Obx(() => Scaffold(
+          appBar: AppBar(
+            title: const Text('Yield Rate Report'),
+            centerTitle: true,
+          ),
+          backgroundColor:
+              isDark ? GlobalColors.bodyDarkBg : GlobalColors.bodyLightBg,
+          body: controller.isLoading.value
+              ? const Center(child: CircularProgressIndicator())
+              : Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Card(
+                        color: bgColor,
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: GestureDetector(
+                                  onTap: () async {
+                                    final picked = await _pickDateTime(
+                                        context, controller.startDateTime.value);
+                                    if (picked != null) {
+                                      controller.updateStart(picked);
+                                    }
+                                  },
+                                  child: Obx(() => Text(
+                                        'From: ${DateFormat('yyyy/MM/dd HH:mm').format(controller.startDateTime.value)}',
+                                        style: TextStyle(
+                                            color: isDark
+                                                ? GlobalColors.darkPrimaryText
+                                                : GlobalColors.lightPrimaryText),
+                                      )),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: GestureDetector(
+                                  onTap: () async {
+                                    final picked = await _pickDateTime(
+                                        context, controller.endDateTime.value);
+                                    if (picked != null) {
+                                      controller.updateEnd(picked);
+                                    }
+                                  },
+                                  child: Obx(() => Text(
+                                        'To:   ${DateFormat('yyyy/MM/dd HH:mm').format(controller.endDateTime.value)}',
+                                        style: TextStyle(
+                                            color: isDark
+                                                ? GlobalColors.darkPrimaryText
+                                                : GlobalColors.lightPrimaryText),
+                                      )),
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.search),
+                                onPressed: () => controller.fetchReport(),
+                              )
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: ListView.builder(
+                        padding: const EdgeInsets.all(12),
+                        itemCount: controller.dataNickNames.length,
+                        itemBuilder: (context, idx) {
+                          final nick = controller.dataNickNames[idx];
+                          final models = nick['DataModelNames'] as List? ?? [];
+                          return Card(
+                            color: bgColor,
+                            child: ExpansionTile(
+                              title: Text(nick['NickName'] ?? ''),
+                              children: models.map<Widget>((m) {
+                                final stations = m['DataStations'] as List? ?? [];
+                                return Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 12, vertical: 8),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(m['ModelName'] ?? '',
+                                          style: const TextStyle(
+                                              fontWeight: FontWeight.bold)),
+                                      const SizedBox(height: 6),
+                                      SingleChildScrollView(
+                                        scrollDirection: Axis.horizontal,
+                                        child: DataTable(
+                                          columns: [
+                                            const DataColumn(label: Text('Station')),
+                                            ...controller.dates
+                                                .map((d) => DataColumn(label: Text(d)))
+                                                .toList(),
+                                          ],
+                                          rows: stations.map<DataRow>((st) {
+                                            final values = (st['Data'] as List? ?? [])
+                                                .map((e) => e.toString())
+                                                .toList();
+                                            return DataRow(cells: [
+                                              DataCell(Text(st['Station'] ?? '')),
+                                              ...values
+                                                  .map((v) => DataCell(Text(v)))
+                                                  .toList(),
+                                            ]);
+                                          }).toList(),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+        ));
+  }
+}

--- a/lib/service/yield_rate_api.dart
+++ b/lib/service/yield_rate_api.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'auth/auth_config.dart';
+
+class YieldRateApi {
+  static const String _url =
+      'https://10.220.130.117/NVIDIA/YieldRate/PostOutputReport';
+
+  static Future<Map<String, dynamic>> getOutputReport({
+    String customer = 'NVIDIA',
+    String type = 'SWITCH',
+    required String rangeDateTime,
+    String nickName = 'All',
+  }) async {
+    final body = json.encode({
+      'Customer': customer,
+      'Type': type,
+      'RangeDateTime': rangeDateTime,
+      'NickName': nickName,
+    });
+
+    final res = await http.post(
+      Uri.parse(_url),
+      headers: AuthConfig.getAuthorizedHeaders(),
+      body: body,
+    );
+
+    if (res.statusCode == 200 && res.body.isNotEmpty) {
+      return json.decode(res.body) as Map<String, dynamic>;
+    } else if (res.statusCode == 204) {
+      return {};
+    } else {
+      throw Exception('Failed to load output report (${res.statusCode})');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enhance `YieldReportController` to store start and end datetimes
- implement date & time pickers in `YieldReportScreen`
- apply theme colors for dark and light modes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881adb76510832586a353a53c1d44f3