### PR TITLE
Fix YieldReport NaN constraints with empty dates

### DIFF
--- a/lib/screen/home/widget/yield_report/yield_report_header_row.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_header_row.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import 'yield_report_table.dart';
+
+class YieldReportHeaderRow extends StatelessWidget {
+  final List dates;
+  final bool isDark;
+  final ScrollController controller;
+
+  const YieldReportHeaderRow({
+    super.key,
+    required this.dates,
+    required this.isDark,
+    required this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget cell(String text, {bool alignLeft = false, double? width}) =>
+        YieldReportTable.buildCell(
+          text,
+          isDark,
+          header: true,
+          alignLeft: alignLeft,
+          width: width,
+        );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final available = constraints.maxWidth - YieldReportTable.stationWidth;
+        double cw = YieldReportTable.cellWidth;
+        if (dates.isNotEmpty && dates.length * YieldReportTable.cellWidth < available) {
+          cw = available / dates.length;
+        }
+        final contentWidth = cw * dates.length;
+        final canCenter = contentWidth <= available;
+        final tableWidth = YieldReportTable.stationWidth + contentWidth;
+
+        return Align(
+          alignment: Alignment.center,
+          child: SizedBox(
+            width: tableWidth,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                cell('Station', alignLeft: true),
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: controller,
+                    scrollDirection: Axis.horizontal,
+                    physics: canCenter ? const NeverScrollableScrollPhysics() : null,
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(minWidth: available),
+                      child: Align(
+                        alignment: canCenter ? Alignment.center : Alignment.centerLeft,
+                        child: Row(
+                          children: dates
+                              .map<Widget>((d) => cell(d.toString(), width: cw))
+                              .toList(),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screen/home/widget/yield_report/yield_report_screen.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_screen.dart
@@ -6,6 +6,8 @@ import '../../../../util/linked_scroll_controller.dart';
 import '../../controller/yield_report_controller.dart';
 import 'yield_report_filter_panel.dart';
 import 'yield_report_table.dart';
+import 'yield_report_header_row.dart';
+import 'yield_report_search_bar.dart';
 
 class YieldReportScreen extends StatefulWidget {
   YieldReportScreen({super.key});
@@ -85,52 +87,9 @@ class _YieldReportScreenState extends State<YieldReportScreen> {
           children: [
             Column(
               children: [
-                Container(
-                  margin: const EdgeInsets.fromLTRB(13, 18, 13, 0),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 13,
-                    vertical: 8,
-                  ),
-                  decoration: BoxDecoration(
-                    color:
-                        isDark
-                            ? GlobalColors.cardDarkBg
-                            : GlobalColors.cardLightBg,
-                    borderRadius: BorderRadius.circular(14),
-                    boxShadow: [
-                      BoxShadow(
-                        color:
-                            isDark
-                                ? Colors.black.withOpacity(0.10)
-                                : Colors.grey.withOpacity(0.13),
-                        blurRadius: 7,
-                        offset: const Offset(0, 3),
-                      ),
-                    ],
-                  ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.search,
-                        color: isDark ? Colors.white54 : Colors.grey[700],
-                      ),
-                      const SizedBox(width: 6),
-                      Expanded(
-                        child: TextField(
-                          style: TextStyle(
-                            color: isDark ? Colors.white : Colors.black87,
-                            fontSize: 16,
-                          ),
-                          decoration: const InputDecoration(
-                            hintText: "Tìm kiếm NickName, Model, Station...",
-                            border: InputBorder.none,
-                            hintStyle: TextStyle(fontWeight: FontWeight.w400),
-                          ),
-                          onChanged: (val) => controller.updateQuickFilter(val),
-                        ),
-                      ),
-                    ],
-                  ),
+                YieldReportSearchBar(
+                  controller: controller,
+                  isDark: isDark,
                 ),
                 const SizedBox(height: 10),
                 const SizedBox(height: 7),
@@ -190,10 +149,10 @@ class _YieldReportScreenState extends State<YieldReportScreen> {
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 4),
-          child: _buildHeaderRow(
-            controller.dates,
-            isDark,
-            _headerController,
+          child: YieldReportHeaderRow(
+            dates: controller.dates,
+            isDark: isDark,
+            controller: _headerController,
           ),
         ),
         Expanded(
@@ -267,56 +226,4 @@ class _YieldReportScreenState extends State<YieldReportScreen> {
     );
   }
 
-  Widget _buildHeaderRow(List dates, bool isDark, ScrollController controller) {
-    Widget cell(String text, {bool alignLeft = false, double? width}) =>
-        YieldReportTable.buildCell(text, isDark,
-            header: true, alignLeft: alignLeft, width: width);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final available =
-            constraints.maxWidth - YieldReportTable.stationWidth;
-        double cw = YieldReportTable.cellWidth;
-        if (dates.length * YieldReportTable.cellWidth < available) {
-          cw = available / dates.length;
-        }
-        final contentWidth = cw * dates.length;
-        final canCenter = contentWidth <= available;
-        final tableWidth = YieldReportTable.stationWidth + contentWidth;
-
-        return Align(
-          alignment: Alignment.center,
-          child: SizedBox(
-            width: tableWidth,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                cell('Station', alignLeft: true),
-                Expanded(
-                  child: SingleChildScrollView(
-                    controller: controller,
-                    scrollDirection: Axis.horizontal,
-                    physics:
-                        canCenter ? const NeverScrollableScrollPhysics() : null,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(minWidth: available),
-                      child: Align(
-                        alignment: canCenter
-                            ? Alignment.center
-                            : Alignment.centerLeft,
-                        child: Row(
-                          children: dates
-                              .map<Widget>((d) => cell(d.toString(), width: cw))
-                              .toList(),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
 }

--- a/lib/screen/home/widget/yield_report/yield_report_search_bar.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_search_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../../controller/yield_report_controller.dart';
+
+class YieldReportSearchBar extends StatelessWidget {
+  final YieldReportController controller;
+  final bool isDark;
+
+  const YieldReportSearchBar({
+    super.key,
+    required this.controller,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(13, 18, 13, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 8),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF37474F) : Colors.white,
+        borderRadius: BorderRadius.circular(14),
+        boxShadow: [
+          BoxShadow(
+            color: isDark ? Colors.black.withOpacity(0.10) : Colors.grey.withOpacity(0.13),
+            blurRadius: 7,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.search,
+            color: isDark ? Colors.white54 : Colors.grey[700],
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: TextField(
+              style: TextStyle(
+                color: isDark ? Colors.white : Colors.black87,
+                fontSize: 16,
+              ),
+              decoration: const InputDecoration(
+                hintText: 'T\u00ecm ki\u1ebfm NickName, Model, Station...',
+                border: InputBorder.none,
+                hintStyle: TextStyle(fontWeight: FontWeight.w400),
+              ),
+              onChanged: controller.updateQuickFilter,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screen/home/widget/yield_report/yield_report_table.dart
+++ b/lib/screen/home/widget/yield_report/yield_report_table.dart
@@ -26,7 +26,7 @@ class YieldReportTable extends StatelessWidget {
       builder: (context, constraints) {
         final available = constraints.maxWidth - stationWidth;
         double cw = cellWidth;
-        if (dates.length * cellWidth < available) {
+        if (dates.isNotEmpty && dates.length * cellWidth < available) {
           cw = available / dates.length;
         }
         final contentWidth = cw * dates.length;


### PR DESCRIPTION
## Summary
- prevent division by zero when no dates are present in YieldReportTable and header
- refactor YieldReportScreen by extracting search bar and header row widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68832076be3083258e47875d282c0e2a