### PR TITLE
feat: add top notification banner

### DIFF
--- a/lib/screen/notification/notification_tab.dart
+++ b/lib/screen/notification/notification_tab.dart
@@ -4,6 +4,7 @@ import 'package:smart_factory/screen/setting/controller/setting_controller.dart'
 import '../../config/global_color.dart';
 import '../../generated/l10n.dart';
 import '../../widget/custom_app_bar.dart';
+import '../../widget/top_notification.dart';
 
 class NotificationTab extends StatefulWidget {
   const NotificationTab({super.key});
@@ -33,7 +34,13 @@ class _NotificationTabState extends State<NotificationTab> {
           accent: GlobalColors.accentByIsDark(isDark),
           titleAlign: TextAlign.left,
         ),
-        body: Container(), // Placeholder
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () =>
+                TopNotification.show(context, 'No notifications'),
+            child: const Text('Show notification'),
+          ),
+        ),
       );
     });
   }

--- a/lib/widget/top_notification.dart
+++ b/lib/widget/top_notification.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+class TopNotification extends StatefulWidget {
+  const TopNotification({
+    super.key,
+    required this.message,
+    required this.onDismissed,
+    this.backgroundColor = Colors.red,
+    this.displayDuration = const Duration(seconds: 3),
+  });
+
+  final String message;
+  final Color backgroundColor;
+  final Duration displayDuration;
+  final VoidCallback onDismissed;
+
+  static void show(
+    BuildContext context,
+    String message, {
+    Color backgroundColor = Colors.red,
+    Duration displayDuration = const Duration(seconds: 3),
+  }) {
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (context) => TopNotification(
+        message: message,
+        backgroundColor: backgroundColor,
+        displayDuration: displayDuration,
+        onDismissed: () => entry.remove(),
+      ),
+    );
+    Overlay.of(context).insert(entry);
+  }
+
+  @override
+  State<TopNotification> createState() => _TopNotificationState();
+}
+
+class _TopNotificationState extends State<TopNotification>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _offsetAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _offsetAnimation = Tween<Offset>(
+      begin: const Offset(0, -1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+
+    _controller.forward();
+    Future.delayed(widget.displayDuration, () async {
+      if (mounted) {
+        await _controller.reverse();
+        widget.onDismissed();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: SlideTransition(
+        position: _offsetAnimation,
+        child: Material(
+          color: widget.backgroundColor,
+          elevation: 6,
+          child: SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                widget.message,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.white),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add animated top notification banner widget
- wire sample button in notification tab

## Testing
- `dart format lib/widget/top_notification.dart lib/screen/notification/notification_tab.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a4df7c4832b9a1da0ac5379516a