### PR TITLE
chore(android): update build tooling to Flutter 3.24 defaults

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.smart_office_aiot"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "29.0.13846066" // Cập nhật NDK phiên bản cao nhất
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("com.android.application") version "8.9.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- align the Android Gradle plugin and Kotlin Gradle plugin versions with the Flutter 3.24 template defaults
- let the Flutter tooling control the NDK version and update the Gradle wrapper to the matching 8.12 release

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c92f55fae4832ba85b57fe5620b597