### PR TITLE
feat: integrate remote notifications

### DIFF
--- a/lib/model/notification_draft.dart
+++ b/lib/model/notification_draft.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+class NotificationDraft {
+  NotificationDraft({
+    this.id,
+    required this.title,
+    required this.body,
+    this.link,
+    this.targetVersion,
+    DateTime? timestampUtc,
+    this.attachment,
+  }) : timestampUtc = (timestampUtc ?? DateTime.now().toUtc());
+
+  final String? id;
+  final String title;
+  final String body;
+  final String? link;
+  final String? targetVersion;
+  final DateTime timestampUtc;
+  final NotificationAttachment? attachment;
+
+  bool get hasAttachment => attachment != null;
+
+  Map<String, dynamic> toJsonPayload() {
+    final payload = <String, dynamic>{
+      'id': id ?? DateTime.now().microsecondsSinceEpoch.toString(),
+      'title': title,
+      'body': body,
+      'link': link ?? '',
+      'targetVersion': targetVersion ?? '',
+      'timestampUtc': timestampUtc.toIso8601String(),
+      'fileUrl': '',
+      'fileBase64': '',
+      'fileName': '',
+    };
+
+    if (hasAttachment && attachment!.bytes != null) {
+      payload['fileBase64'] = base64Encode(attachment!.bytes!);
+      payload['fileName'] = attachment!.fileName;
+    }
+
+    return payload;
+  }
+}
+
+class NotificationAttachment {
+  const NotificationAttachment({
+    required this.fileName,
+    this.bytes,
+    this.filePath,
+    this.size,
+  });
+
+  final String fileName;
+  final List<int>? bytes;
+  final String? filePath;
+  final int? size;
+
+  bool get hasBytes => bytes != null;
+}

--- a/lib/model/notification_message.dart
+++ b/lib/model/notification_message.dart
@@ -1,0 +1,92 @@
+import 'package:intl/intl.dart';
+
+class NotificationMessage {
+  const NotificationMessage({
+    required this.id,
+    required this.title,
+    required this.body,
+    this.link,
+    this.targetVersion,
+    this.timestampUtc,
+    this.fileUrl,
+    this.fileName,
+  });
+
+  final String? id;
+  final String title;
+  final String body;
+  final String? link;
+  final String? targetVersion;
+  final DateTime? timestampUtc;
+  final String? fileUrl;
+  final String? fileName;
+
+  factory NotificationMessage.fromJson(Map<String, dynamic> json) {
+    DateTime? parsedTimestamp;
+    final dynamic ts = json['timestampUtc'] ?? json['timestamp'];
+    if (ts is String && ts.isNotEmpty) {
+      parsedTimestamp = DateTime.tryParse(ts)?.toUtc();
+    } else if (ts is int) {
+      parsedTimestamp = DateTime.fromMillisecondsSinceEpoch(ts).toUtc();
+    }
+
+    return NotificationMessage(
+      id: json['id']?.toString(),
+      title: (json['title'] ?? '').toString(),
+      body: (json['body'] ?? '').toString(),
+      link: _normalizeOptional(json['link']),
+      targetVersion: _normalizeOptional(json['targetVersion']),
+      timestampUtc: parsedTimestamp,
+      fileUrl: _normalizeOptional(json['fileUrl']),
+      fileName: _normalizeOptional(json['fileName']),
+    );
+  }
+
+  static List<NotificationMessage> listFrom(dynamic data) {
+    if (data is List) {
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(NotificationMessage.fromJson)
+          .toList();
+    }
+    if (data is Map<String, dynamic>) {
+      for (final key in ['items', 'data', 'notifications', 'results']) {
+        final value = data[key];
+        if (value is List) {
+          return value
+              .whereType<Map<String, dynamic>>()
+              .map(NotificationMessage.fromJson)
+              .toList();
+        }
+      }
+      if (data.containsKey('id') && data.containsKey('title')) {
+        return [NotificationMessage.fromJson(data)];
+      }
+    }
+    return const <NotificationMessage>[];
+  }
+
+  DateTime? get timestampLocal => timestampUtc?.toLocal();
+
+  String? get formattedTimestamp {
+    final local = timestampLocal;
+    if (local == null) return null;
+    return DateFormat('dd/MM/yyyy HH:mm').format(local);
+  }
+
+  bool get hasLink => link != null && link!.trim().isNotEmpty;
+  bool get hasAttachment {
+    final hasUrl = fileUrl != null && fileUrl!.trim().isNotEmpty;
+    final hasName = fileName != null && fileName!.trim().isNotEmpty;
+    return hasUrl || hasName;
+  }
+
+  static String? _normalizeOptional(dynamic value) {
+    if (value == null) return null;
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    return value.toString();
+  }
+}

--- a/lib/screen/notification/controller/notification_controller.dart
+++ b/lib/screen/notification/controller/notification_controller.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:get/get.dart';
+
+import '../../../model/notification_draft.dart';
+import '../../../model/notification_message.dart';
+import '../../../service/notification_service.dart';
+
+class NotificationController extends GetxController {
+  NotificationController({this.pageSize = 20});
+
+  final int pageSize;
+
+  final RxList<NotificationMessage> notifications = <NotificationMessage>[].obs;
+  final RxBool isLoading = false.obs;
+  final RxBool isLoadingMore = false.obs;
+  final RxBool isSending = false.obs;
+  final RxBool isClearing = false.obs;
+  final RxnString error = RxnString();
+
+  int _currentPage = 1;
+  bool _hasMore = true;
+  bool _fetching = false;
+  Timer? _pollTimer;
+
+  bool get hasMore => _hasMore;
+  bool get isFetching => _fetching;
+
+  @override
+  void onInit() {
+    super.onInit();
+    refreshNotifications(showLoader: true);
+    _startPolling();
+  }
+
+  @override
+  void onClose() {
+    _pollTimer?.cancel();
+    super.onClose();
+  }
+
+  Future<void> refreshNotifications({bool showLoader = false}) async {
+    if (_fetching) return;
+    _currentPage = 1;
+    _hasMore = true;
+    await _load(page: 1, append: false, showLoader: showLoader);
+  }
+
+  Future<void> loadMore() async {
+    if (!_hasMore || _fetching) return;
+    isLoadingMore.value = true;
+    try {
+      await _load(page: _currentPage + 1, append: true);
+    } finally {
+      isLoadingMore.value = false;
+    }
+  }
+
+  Future<void> sendNotification(NotificationDraft draft) async {
+    if (isSending.value) return;
+    isSending.value = true;
+    try {
+      await NotificationService.sendNotification(draft);
+      await refreshNotifications(showLoader: notifications.isEmpty);
+      error.value = null;
+    } catch (e) {
+      error.value = e.toString();
+      rethrow;
+    } finally {
+      isSending.value = false;
+    }
+  }
+
+  Future<void> clearAll() async {
+    if (isClearing.value) return;
+    isClearing.value = true;
+    try {
+      await NotificationService.clearNotifications();
+      notifications.clear();
+      _currentPage = 1;
+      _hasMore = true;
+      error.value = null;
+    } catch (e) {
+      error.value = e.toString();
+      rethrow;
+    } finally {
+      isClearing.value = false;
+    }
+  }
+
+  Future<void> _load({
+    required int page,
+    required bool append,
+    bool showLoader = false,
+  }) async {
+    if (_fetching) return;
+    _fetching = true;
+    if (showLoader) {
+      isLoading.value = true;
+    }
+
+    try {
+      final result = await NotificationService.fetchNotifications(
+        page: page,
+        pageSize: pageSize,
+      );
+
+      if (!append) {
+        notifications.assignAll(result);
+      } else if (result.isNotEmpty) {
+        final existingIds = notifications
+            .map((item) => item.id)
+            .whereType<String>()
+            .toSet();
+        for (final item in result) {
+          final id = item.id;
+          if (id != null && existingIds.contains(id)) {
+            continue;
+          }
+          notifications.add(item);
+        }
+      }
+
+      _currentPage = page;
+      _hasMore = result.length >= pageSize;
+      error.value = null;
+    } catch (e) {
+      error.value = e.toString();
+      if (!append && notifications.isEmpty) {
+        notifications.clear();
+      }
+    } finally {
+      if (showLoader) {
+        isLoading.value = false;
+      }
+      _fetching = false;
+    }
+  }
+
+  void _startPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = Timer.periodic(const Duration(seconds: 30), (_) async {
+      if (_fetching) return;
+      await refreshNotifications(showLoader: false);
+    });
+  }
+}

--- a/lib/screen/notification/notification_tab.dart
+++ b/lib/screen/notification/notification_tab.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:smart_factory/screen/setting/controller/setting_controller.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../config/Apiconfig.dart';
 import '../../config/global_color.dart';
 import '../../generated/l10n.dart';
+import '../../model/notification_draft.dart';
+import '../../model/notification_message.dart';
 import '../../widget/custom_app_bar.dart';
+import '../../widget/notification/notification_card.dart';
+import '../../widget/notification/notification_compose_dialog.dart';
+import '../setting/controller/setting_controller.dart';
+import 'controller/notification_controller.dart';
 
 class NotificationTab extends StatefulWidget {
   const NotificationTab({super.key});
@@ -14,11 +22,335 @@ class NotificationTab extends StatefulWidget {
 
 class _NotificationTabState extends State<NotificationTab> {
   late final SettingController settingController;
+  late final NotificationController notificationController;
+  late final ScrollController _scrollController;
 
   @override
   void initState() {
     super.initState();
     settingController = Get.find<SettingController>();
+    notificationController = Get.isRegistered<NotificationController>()
+        ? Get.find<NotificationController>()
+        : Get.put(NotificationController());
+    _scrollController = ScrollController()..addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    if (_scrollController.position.extentAfter < 320) {
+      notificationController.loadMore();
+    }
+  }
+
+  Future<void> _onRefresh() {
+    return notificationController.refreshNotifications(showLoader: false);
+  }
+
+  Future<void> _openComposer() async {
+    final isDark = settingController.isDarkMode.value;
+    final draft = await showDialog<NotificationDraft>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => NotificationComposeDialog(isDark: isDark),
+    );
+
+    if (draft == null) return;
+
+    try {
+      await notificationController.sendNotification(draft);
+      if (!mounted) return;
+      Get.snackbar(
+        'Thành công',
+        'Thông báo đã được gửi tới các thiết bị.',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.green.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      Get.snackbar(
+        'Gửi thông báo thất bại',
+        e.toString(),
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.redAccent.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    }
+  }
+
+  Future<void> _confirmClear() async {
+    final isDark = settingController.isDarkMode.value;
+    final accent = GlobalColors.accentByIsDark(isDark);
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor:
+            isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        title: const Text('Xoá toàn bộ thông báo?'),
+        content: const Text(
+          'Thao tác này sẽ xoá toàn bộ thông báo đã gửi đi. Bạn có chắc chắn?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Huỷ'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: accent,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Xoá hết'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true) return;
+
+    try {
+      await notificationController.clearAll();
+      if (!mounted) return;
+      Get.snackbar(
+        'Đã xoá',
+        'Danh sách thông báo đã được dọn sạch.',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.green.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      Get.snackbar(
+        'Không thể xoá thông báo',
+        e.toString(),
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.redAccent.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    }
+  }
+
+  Future<void> _openLink(String? rawUrl) async {
+    if (rawUrl == null || rawUrl.trim().isEmpty) return;
+    final uri = _parseUri(rawUrl);
+    if (uri == null) {
+      Get.snackbar(
+        'Liên kết không hợp lệ',
+        rawUrl,
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.orangeAccent.withOpacity(0.9),
+        colorText: Colors.white,
+      );
+      return;
+    }
+
+    final success = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!success) {
+      Get.snackbar(
+        'Không thể mở liên kết',
+        uri.toString(),
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.redAccent.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    }
+  }
+
+  Future<void> _openAttachment(NotificationMessage message) async {
+    final raw = message.fileUrl;
+    if (raw == null || raw.isEmpty) {
+      Get.snackbar(
+        'Không có tệp đính kèm',
+        message.fileName ?? '',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+    final resolved = _resolveResourceUrl(raw);
+    final uri = Uri.tryParse(resolved);
+    if (uri == null) {
+      Get.snackbar(
+        'Đường dẫn tệp không hợp lệ',
+        resolved,
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.orangeAccent.withOpacity(0.9),
+        colorText: Colors.white,
+      );
+      return;
+    }
+    final success = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (!success) {
+      Get.snackbar(
+        'Không thể mở tệp đính kèm',
+        message.fileName ?? uri.toString(),
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.redAccent.withOpacity(0.85),
+        colorText: Colors.white,
+      );
+    }
+  }
+
+  Uri? _parseUri(String url) {
+    final trimmed = url.trim();
+    if (trimmed.isEmpty) return null;
+    Uri? uri = Uri.tryParse(trimmed);
+    if (uri == null) return null;
+    if (!uri.hasScheme) {
+      uri = Uri.tryParse('https://$trimmed');
+    }
+    if (uri == null || !uri.hasScheme) return null;
+    return uri;
+  }
+
+  String _resolveResourceUrl(String url) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      return url;
+    }
+    final base = ApiConfig.baseUrl.endsWith('/')
+        ? ApiConfig.baseUrl.substring(0, ApiConfig.baseUrl.length - 1)
+        : ApiConfig.baseUrl;
+    if (url.startsWith('/')) {
+      return '$base$url';
+    }
+    return '$base/$url';
+  }
+
+  Widget _buildErrorBanner(bool isDark, String message, Color accent) {
+    final bgColor = Colors.redAccent.withOpacity(isDark ? 0.18 : 0.12);
+    final borderColor = Colors.redAccent.withOpacity(0.5);
+    final textColor = isDark ? Colors.red[100]! : Colors.red[900]!;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.error_outline, color: Colors.redAccent),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                color: textColor,
+                fontSize: 14,
+                height: 1.3,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () =>
+                notificationController.refreshNotifications(showLoader: true),
+            child: const Text('Thử lại'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(
+    BuildContext context,
+    bool isDark,
+    String? errorMessage,
+    Color accent,
+  ) {
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    return RefreshIndicator(
+      color: accent,
+      onRefresh: _onRefresh,
+      child: ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          SizedBox(height: screenHeight * 0.15),
+          Icon(
+            Icons.notifications_off_outlined,
+            size: 72,
+            color: accent.withOpacity(0.8),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Chưa có thông báo nào',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: isDark
+                  ? GlobalColors.darkPrimaryText
+                  : GlobalColors.lightPrimaryText,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              errorMessage?.isNotEmpty == true
+                  ? errorMessage!
+                  : 'Nhấn nút “Gửi thông báo” để đẩy thông báo tới thiết bị.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                height: 1.4,
+                color: isDark
+                    ? GlobalColors.darkSecondaryText
+                    : GlobalColors.lightSecondaryText,
+              ),
+            ),
+          ),
+          const SizedBox(height: 80),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(
+    bool isDark,
+    Color accent,
+    List<NotificationMessage> notifications,
+    bool isLoadingMore,
+  ) {
+    return RefreshIndicator(
+      color: accent,
+      onRefresh: _onRefresh,
+      child: ListView.separated(
+        controller: _scrollController,
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+        itemCount: notifications.length + (isLoadingMore ? 1 : 0),
+        separatorBuilder: (_, __) => const SizedBox(height: 16),
+        itemBuilder: (context, index) {
+          if (index >= notifications.length) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                child: CircularProgressIndicator(color: accent),
+              ),
+            );
+          }
+          final message = notifications[index];
+          return NotificationCard(
+            message: message,
+            isDark: isDark,
+            accent: accent,
+            onOpenLink: message.hasLink ? () => _openLink(message.link) : null,
+            onOpenAttachment:
+                message.hasAttachment ? () => _openAttachment(message) : null,
+          );
+        },
+      ),
+    );
   }
 
   @override
@@ -26,14 +358,77 @@ class _NotificationTabState extends State<NotificationTab> {
     final S text = S.of(context);
     return Obx(() {
       final bool isDark = settingController.isDarkMode.value;
+      final Color accent = GlobalColors.accentByIsDark(isDark);
+      final notifications = notificationController.notifications;
+      final isLoading = notificationController.isLoading.value;
+      final isSending = notificationController.isSending.value;
+      final isLoadingMore = notificationController.isLoadingMore.value;
+      final errorMessage = notificationController.error.value;
+
+      Widget bodyContent;
+      if (isLoading && notifications.isEmpty) {
+        bodyContent = const Center(child: CircularProgressIndicator());
+      } else if (notifications.isEmpty) {
+        bodyContent = _buildEmptyState(context, isDark, errorMessage, accent);
+      } else {
+        bodyContent = _buildList(
+          isDark,
+          accent,
+          notifications,
+          isLoadingMore,
+        );
+      }
+
       return Scaffold(
         appBar: CustomAppBar(
           title: Text(text.notification),
           isDark: isDark,
-          accent: GlobalColors.accentByIsDark(isDark),
+          accent: accent,
           titleAlign: TextAlign.left,
+          actions: [
+            IconButton(
+              tooltip: 'Làm mới',
+              onPressed: () =>
+                  notificationController.refreshNotifications(showLoader: true),
+              icon: const Icon(Icons.refresh),
+              color: accent,
+            ),
+            IconButton(
+              tooltip: 'Xoá toàn bộ',
+              onPressed:
+                  notifications.isEmpty ? null : () => _confirmClear(),
+              icon: const Icon(Icons.delete_sweep_outlined),
+              color: notifications.isEmpty
+                  ? accent.withOpacity(0.3)
+                  : accent,
+            ),
+          ],
         ),
-        body: Container(), // Placeholder
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: isSending ? null : _openComposer,
+          icon: isSending
+              ? const SizedBox(
+                  width: 22,
+                  height: 22,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2.5,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Icon(Icons.add),
+          label:
+              Text(isSending ? 'Đang gửi...' : 'Gửi thông báo'),
+          backgroundColor:
+              isSending ? accent.withOpacity(0.6) : accent,
+          foregroundColor: Colors.white,
+        ),
+        body: Column(
+          children: [
+            if (errorMessage != null && errorMessage.trim().isNotEmpty)
+              _buildErrorBanner(isDark, errorMessage, accent),
+            Expanded(child: bodyContent),
+          ],
+        ),
       );
     });
   }

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -1,85 +1,215 @@
-// import 'dart:convert';
-// import 'dart:io';
-// import 'package:http/http.dart' as http;
-// import 'package:http/io_client.dart';
-//
-// class NotificationService {
-//   static final String _baseUrl = "https://localhost:7283/api/Control/";
-//
-//   static IOClient _getInsecureClient() {
-//     final httpClient = HttpClient()
-//       ..badCertificateCallback = (cert, host, port) => true;
-//     return IOClient(httpClient);
-//   }
-//
-//   static Future<List<NotificationMessage>> getAllNotifications() async {
-//     final url = Uri.parse("${_baseUrl}get-notifications");
-//     final client = _getInsecureClient();
-//     final res = await client.get(url);
-//
-//     print('[DEBUG] GET $url');
-//     print('[DEBUG] Status: ${res.statusCode}');
-//     print('[DEBUG] Body: ${res.body}');
-//
-//     if (res.statusCode == 200 && res.body.isNotEmpty) {
-//       final List<dynamic> data = json.decode(res.body);
-//       return data
-//           .map((e) => NotificationMessage.fromJson(e))
-//           .toList();
-//     } else if (res.statusCode == 204) {
-//       return [];
-//     } else {
-//       throw Exception('Failed to fetch notifications (${res.statusCode})');
-//     }
-//   }
-//
-//   static Future<bool> sendNotification({
-//     required String title,
-//     required String body,
-//   }) async {
-//     final url = Uri.parse("${_baseUrl}send-notification");
-//     final client = _getInsecureClient();
-//     final payload = json.encode({
-//       "title": title,
-//       "body": body,
-//     });
-//
-//     print('[DEBUG] POST $url');
-//     print('[DEBUG] Body: $payload');
-//
-//     final res = await client.post(url,
-//         headers: {"Content-Type": "application/json"}, body: payload);
-//
-//     print('[DEBUG] Status: ${res.statusCode}');
-//     print('[DEBUG] Body: ${res.body}');
-//
-//     return res.statusCode == 200;
-//   }
-//
-//   static Future<bool> clearNotifications() async {
-//     final url = Uri.parse("${_baseUrl}clear-notifications");
-//     final client = _getInsecureClient();
-//     final res = await client.post(url);
-//     return res.statusCode == 200;
-//   }
-// }
-//
-// class NotificationMessage {
-//   final String title;
-//   final String body;
-//   final DateTime timestamp;
-//
-//   NotificationMessage({
-//     required this.title,
-//     required this.body,
-//     required this.timestamp,
-//   });
-//
-//   factory NotificationMessage.fromJson(Map<String, dynamic> json) {
-//     return NotificationMessage(
-//       title: json['title'],
-//       body: json['body'],
-//       timestamp: DateTime.parse(json['timestamp']),
-//     );
-//   }
-// }
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+import '../config/Apiconfig.dart';
+import '../model/notification_draft.dart';
+import '../model/notification_message.dart';
+
+class NotificationService {
+  NotificationService._();
+
+  static final Uri _baseUri = Uri.parse(ApiConfig.baseUrl);
+
+  static Uri _uri(String path, [Map<String, dynamic>? query]) {
+    final base = ApiConfig.baseUrl.endsWith('/')
+        ? ApiConfig.baseUrl.substring(0, ApiConfig.baseUrl.length - 1)
+        : ApiConfig.baseUrl;
+    final normalizedPath = path.startsWith('/') ? path : '/$path';
+    final uri = Uri.parse('$base$normalizedPath');
+    if (query == null || query.isEmpty) {
+      return uri;
+    }
+    final queryParams = <String, String>{};
+    query.forEach((key, value) {
+      if (value != null) {
+        queryParams[key] = value.toString();
+      }
+    });
+    return uri.replace(queryParameters: queryParams);
+  }
+
+  static HttpClient _createHttpClient() {
+    final client = HttpClient();
+    if (_baseUri.scheme == 'https') {
+      client.badCertificateCallback =
+          (cert, host, port) => host == _baseUri.host;
+    }
+    return client;
+  }
+
+  static IOClient _createIoClient() => IOClient(_createHttpClient());
+
+  static Future<List<NotificationMessage>> fetchNotifications({
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    final uri = _uri('/api/Control/get-notifications', {
+      'page': page,
+      'pageSize': pageSize,
+    });
+    final client = _createIoClient();
+    try {
+      final response = await client
+          .get(uri, headers: {HttpHeaders.acceptHeader: 'application/json'})
+          .timeout(const Duration(seconds: 20));
+
+      if (response.statusCode == HttpStatus.noContent) {
+        return const [];
+      }
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception(
+          'Không thể tải danh sách thông báo (mã ${response.statusCode}). ${_extractError(response.body) ?? ''}',
+        );
+      }
+
+      final body = response.body.trim();
+      if (body.isEmpty) {
+        return const [];
+      }
+
+      final dynamic decoded = jsonDecode(body);
+      final items = NotificationMessage.listFrom(decoded);
+      items.sort((a, b) {
+        final DateTime ta = a.timestampUtc ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final DateTime tb = b.timestampUtc ?? DateTime.fromMillisecondsSinceEpoch(0);
+        return tb.compareTo(ta);
+      });
+      return items;
+    } on FormatException catch (e) {
+      throw Exception('Dữ liệu thông báo không hợp lệ: ${e.message}');
+    } finally {
+      client.close();
+    }
+  }
+
+  static Future<void> sendNotification(NotificationDraft draft) async {
+    if (draft.hasAttachment &&
+        draft.attachment?.bytes == null &&
+        (draft.attachment?.filePath?.isEmpty ?? true)) {
+      throw ArgumentError('Tệp đính kèm không hợp lệ');
+    }
+
+    if (draft.hasAttachment) {
+      await _sendMultipart(draft);
+    } else {
+      await _sendJson(draft);
+    }
+  }
+
+  static Future<void> clearNotifications() async {
+    final uri = _uri('/api/Control/clear-notifications');
+    final client = _createIoClient();
+    try {
+      final response = await client
+          .post(uri, headers: {HttpHeaders.acceptHeader: 'application/json'})
+          .timeout(const Duration(seconds: 20));
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception(
+          'Không thể xoá thông báo (mã ${response.statusCode}). ${_extractError(response.body) ?? ''}',
+        );
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  static Future<void> _sendJson(NotificationDraft draft) async {
+    final uri = _uri('/api/Control/send-notification-json');
+    final client = _createIoClient();
+    try {
+      final payload = draft.toJsonPayload();
+      final response = await client
+          .post(
+            uri,
+            headers: {
+              HttpHeaders.contentTypeHeader: 'application/json',
+              HttpHeaders.acceptHeader: 'application/json',
+            },
+            body: jsonEncode(payload),
+          )
+          .timeout(const Duration(seconds: 20));
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception(
+          'Gửi thông báo thất bại (mã ${response.statusCode}). ${_extractError(response.body) ?? ''}',
+        );
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  static Future<void> _sendMultipart(NotificationDraft draft) async {
+    final uri = _uri('/api/Control/send-notification');
+    final request = http.MultipartRequest('POST', uri);
+
+    request.fields['Title'] = draft.title;
+    request.fields['Body'] = draft.body;
+    request.fields['TimestampUtc'] = draft.timestampUtc.toIso8601String();
+    if (draft.id != null && draft.id!.isNotEmpty) {
+      request.fields['Id'] = draft.id!;
+    }
+    if (draft.link != null && draft.link!.isNotEmpty) {
+      request.fields['Link'] = draft.link!;
+    }
+    if (draft.targetVersion != null && draft.targetVersion!.isNotEmpty) {
+      request.fields['TargetVersion'] = draft.targetVersion!;
+    }
+
+    final attachment = draft.attachment;
+    if (attachment != null) {
+      if (attachment.hasBytes) {
+        request.files.add(http.MultipartFile.fromBytes(
+          'File',
+          attachment.bytes!,
+          filename: attachment.fileName,
+        ));
+      } else if (attachment.filePath != null && attachment.filePath!.isNotEmpty) {
+        request.files.add(await http.MultipartFile.fromPath(
+          'File',
+          attachment.filePath!,
+          filename: attachment.fileName,
+        ));
+      }
+    }
+
+    final client = _createIoClient();
+    try {
+      final streamed = await client.send(request);
+      final response = await http.Response.fromStream(streamed);
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception(
+          'Gửi thông báo thất bại (mã ${response.statusCode}). ${_extractError(response.body) ?? ''}',
+        );
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  static String? _extractError(String? body) {
+    if (body == null || body.isEmpty) return null;
+    final raw = body.trim();
+    if (raw.isEmpty) return null;
+    try {
+      final dynamic decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        for (final key in ['message', 'error', 'detail']) {
+          final value = decoded[key];
+          if (value is String && value.isNotEmpty) {
+            return value;
+          }
+        }
+      }
+    } catch (_) {
+      return raw;
+    }
+    return raw;
+  }
+}

--- a/lib/widget/notification/notification_card.dart
+++ b/lib/widget/notification/notification_card.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+import '../../config/global_color.dart';
+import '../../model/notification_message.dart';
+
+class NotificationCard extends StatelessWidget {
+  const NotificationCard({
+    super.key,
+    required this.message,
+    required this.isDark,
+    required this.accent,
+    this.onOpenLink,
+    this.onOpenAttachment,
+  });
+
+  final NotificationMessage message;
+  final bool isDark;
+  final Color accent;
+  final VoidCallback? onOpenLink;
+  final VoidCallback? onOpenAttachment;
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryTextColor =
+        isDark ? GlobalColors.darkPrimaryText : GlobalColors.lightPrimaryText;
+    final secondaryTextColor = isDark
+        ? GlobalColors.darkSecondaryText
+        : GlobalColors.lightSecondaryText;
+    final cardColor =
+        isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg;
+
+    final actions = <Widget>[];
+
+    final targetVersion = message.targetVersion;
+    if (targetVersion != null && targetVersion.isNotEmpty) {
+      actions.add(
+        Chip(
+          backgroundColor: accent.withOpacity(isDark ? 0.18 : 0.12),
+          labelStyle: TextStyle(
+            color: accent,
+            fontWeight: FontWeight.w600,
+          ),
+          label: Text('Version $targetVersion'),
+        ),
+      );
+    }
+
+    if (message.hasLink) {
+      actions.add(
+        TextButton.icon(
+          onPressed: onOpenLink,
+          icon: Icon(Icons.link, color: accent, size: 20),
+          label: SizedBox(
+            width: 180,
+            child: Text(
+              message.link!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: accent, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (message.hasAttachment) {
+      final fileLabel = message.fileName ?? 'Tập tin đính kèm';
+      actions.add(
+        TextButton.icon(
+          onPressed: onOpenAttachment,
+          icon: Icon(Icons.attach_file, color: accent, size: 20),
+          label: SizedBox(
+            width: 180,
+            child: Text(
+              fileLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: accent, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(18),
+        boxShadow: [
+          BoxShadow(
+            color: isDark
+                ? Colors.black.withOpacity(0.35)
+                : Colors.blueGrey.withOpacity(0.12),
+            blurRadius: 18,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: accent.withOpacity(isDark ? 0.22 : 0.15),
+                  shape: BoxShape.circle,
+                ),
+                padding: const EdgeInsets.all(12),
+                child: Icon(
+                  Icons.notifications_active_outlined,
+                  color: accent,
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      message.title,
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                        color: primaryTextColor,
+                      ),
+                    ),
+                    if (message.formattedTimestamp != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Text(
+                          message.formattedTimestamp!,
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: secondaryTextColor,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          SelectableText(
+            message.body,
+            style: TextStyle(
+              fontSize: 15,
+              height: 1.4,
+              color: primaryTextColor,
+            ),
+          ),
+          if (actions.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: actions,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widget/notification/notification_compose_dialog.dart
+++ b/lib/widget/notification/notification_compose_dialog.dart
@@ -1,0 +1,244 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../../config/global_color.dart';
+import '../../model/notification_draft.dart';
+
+class NotificationComposeDialog extends StatefulWidget {
+  const NotificationComposeDialog({super.key, required this.isDark});
+
+  final bool isDark;
+
+  @override
+  State<NotificationComposeDialog> createState() =>
+      _NotificationComposeDialogState();
+}
+
+class _NotificationComposeDialogState extends State<NotificationComposeDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _titleCtrl;
+  late final TextEditingController _bodyCtrl;
+  late final TextEditingController _linkCtrl;
+  late final TextEditingController _targetCtrl;
+
+  NotificationAttachment? _attachment;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleCtrl = TextEditingController();
+    _bodyCtrl = TextEditingController();
+    _linkCtrl = TextEditingController();
+    _targetCtrl = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _bodyCtrl.dispose();
+    _linkCtrl.dispose();
+    _targetCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(withData: true);
+    if (result == null || result.files.isEmpty) {
+      return;
+    }
+    final file = result.files.first;
+    setState(() {
+      _attachment = NotificationAttachment(
+        fileName: file.name,
+        bytes: file.bytes,
+        filePath: file.path,
+        size: file.size,
+      );
+    });
+  }
+
+  void _removeAttachment() {
+    setState(() {
+      _attachment = null;
+    });
+  }
+
+  String _formatFileSize(int? bytes) {
+    if (bytes == null) return '';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    double value = bytes.toDouble();
+    int unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex++;
+    }
+    return '${value.toStringAsFixed(unitIndex == 0 ? 0 : 1)} ${units[unitIndex]}';
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final draft = NotificationDraft(
+      title: _titleCtrl.text.trim(),
+      body: _bodyCtrl.text.trim(),
+      link: _linkCtrl.text.trim().isEmpty ? null : _linkCtrl.text.trim(),
+      targetVersion:
+          _targetCtrl.text.trim().isEmpty ? null : _targetCtrl.text.trim(),
+      attachment: _attachment,
+    );
+
+    Navigator.of(context).pop(draft);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = widget.isDark;
+    final dialogColor = isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg;
+    final textColor = isDark ? GlobalColors.darkPrimaryText : GlobalColors.lightPrimaryText;
+    final accent = GlobalColors.accentByIsDark(isDark);
+
+    return AlertDialog(
+      backgroundColor: dialogColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      title: Row(
+        children: [
+          Icon(Icons.notifications_active_outlined, color: accent),
+          const SizedBox(width: 8),
+          const Text('Gửi thông báo mới'),
+        ],
+      ),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 500),
+        child: SingleChildScrollView(
+          child: Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextFormField(
+                  controller: _titleCtrl,
+                  style: TextStyle(color: textColor),
+                  decoration: const InputDecoration(
+                    labelText: 'Tiêu đề',
+                    border: OutlineInputBorder(),
+                  ),
+                  textInputAction: TextInputAction.next,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Tiêu đề không được để trống';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _bodyCtrl,
+                  style: TextStyle(color: textColor),
+                  decoration: const InputDecoration(
+                    labelText: 'Nội dung',
+                    alignLabelWithHint: true,
+                    border: OutlineInputBorder(),
+                  ),
+                  maxLines: 5,
+                  minLines: 3,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Vui lòng nhập nội dung thông báo';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _linkCtrl,
+                  style: TextStyle(color: textColor),
+                  decoration: const InputDecoration(
+                    labelText: 'Liên kết (tuỳ chọn)',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _targetCtrl,
+                  style: TextStyle(color: textColor),
+                  decoration: const InputDecoration(
+                    labelText: 'Target version (tuỳ chọn)',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: OutlinedButton.icon(
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: accent,
+                      side: BorderSide(color: accent.withOpacity(0.6)),
+                    ),
+                    onPressed: _pickFile,
+                    icon: const Icon(Icons.attach_file),
+                    label: const Text('Đính kèm tệp (tuỳ chọn)'),
+                  ),
+                ),
+                if (_attachment != null)
+                  Container(
+                    margin: const EdgeInsets.only(top: 12),
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: accent.withOpacity(isDark ? 0.12 : 0.08),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(Icons.insert_drive_file, color: accent),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                _attachment!.fileName,
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: textColor,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              if (_attachment!.size != null)
+                                Text(
+                                  _formatFileSize(_attachment!.size),
+                                  style: TextStyle(color: textColor.withOpacity(0.7), fontSize: 12),
+                                ),
+                            ],
+                          ),
+                        ),
+                        IconButton(
+                          tooltip: 'Gỡ tệp',
+                          onPressed: _removeAttachment,
+                          icon: Icon(Icons.close, color: accent),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Huỷ'),
+        ),
+        ElevatedButton(
+          onPressed: _submit,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: accent,
+            foregroundColor: Colors.white,
+          ),
+          child: const Text('Gửi thông báo'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add models and service helpers for RemoteControl notification APIs
- create GetX controller with polling, sending, clearing, and pagination logic
- build notification tab UI with composer dialog, list rendering, and attachment/link handling

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca0e32e610832ba71046d1994f0b6b