### PR TITLE
Redesign notification card UI

### DIFF
--- a/lib/widget/notification/notification_card.dart
+++ b/lib/widget/notification/notification_card.dart
@@ -21,57 +21,72 @@ class NotificationCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final primaryTextColor =
+    final Color primaryTextColor =
         isDark ? GlobalColors.darkPrimaryText : GlobalColors.lightPrimaryText;
-    final secondaryTextColor =
-        isDark ? GlobalColors.darkSecondaryText : GlobalColors.lightSecondaryText;
-    final baseCardColor =
-        isDark ? GlobalColors.cardDarkBg : GlobalColors.cardLightBg;
-    final accentOverlay = accent.withOpacity(isDark ? 0.22 : 0.12);
-    final cardColor = isUnread
-        ? Color.lerp(baseCardColor, accentOverlay, 0.45) ?? accentOverlay
-        : baseCardColor;
-    final borderColor = isUnread
-        ? accent.withOpacity(isDark ? 0.55 : 0.45)
-        : Colors.transparent;
-    final glowColor = accent.withOpacity(
-      isUnread ? (isDark ? 0.22 : 0.18) : (isDark ? 0.12 : 0.08),
-    );
-    final haloOpacity = isUnread ? (isDark ? 0.24 : 0.18) : (isDark ? 0.14 : 0.08);
+    final Color secondaryTextColor = isDark
+        ? GlobalColors.darkSecondaryText
+        : GlobalColors.lightSecondaryText;
 
+    final Color baseCardColor =
+        isDark ? const Color(0xFF10192B) : Colors.white;
+    final Color unreadTint = accent.withOpacity(isDark ? 0.28 : 0.18);
+    final Color cardColor = isUnread
+        ? Color.lerp(baseCardColor, unreadTint, 0.6) ?? baseCardColor
+        : baseCardColor;
+    final Color outlineColor = isUnread
+        ? accent.withOpacity(isDark ? 0.65 : 0.4)
+        : (isDark ? Colors.white.withOpacity(0.06) : const Color(0xFFE4E8F2));
+
+    final List<BoxShadow> shadows = [
+      BoxShadow(
+        color:
+            isDark ? Colors.black.withOpacity(0.55) : Colors.black.withOpacity(0.08),
+        blurRadius: 28,
+        offset: const Offset(0, 18),
+      ),
+      if (isUnread)
+        BoxShadow(
+          color: accent.withOpacity(isDark ? 0.4 : 0.26),
+          blurRadius: 36,
+          spreadRadius: 1,
+          offset: const Offset(0, 20),
+        ),
+    ];
+
+    final String title = message.title.trim().isNotEmpty
+        ? message.title.trim()
+        : 'Thông báo';
+    final String bodyText = message.body.trim();
+    final bool hasBody = bodyText.isNotEmpty;
     final String? timestamp = message.formattedTimestamp;
+
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(24),
         onTap: onTap,
         child: Container(
           decoration: BoxDecoration(
             color: cardColor,
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: borderColor, width: 1),
-            boxShadow: [
-              BoxShadow(
-                color: glowColor,
-                blurRadius: isUnread ? 22 : 12,
-                spreadRadius: isUnread ? 2.2 : 0,
-                offset: const Offset(0, 10),
-              ),
-            ],
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: outlineColor,
+              width: isUnread ? 1.4 : 1,
+            ),
+            boxShadow: shadows,
           ),
           child: Stack(
-            clipBehavior: Clip.none,
             children: [
               Positioned.fill(
                 child: ClipRRect(
-                  borderRadius: BorderRadius.circular(20),
+                  borderRadius: BorderRadius.circular(24),
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       gradient: LinearGradient(
                         begin: Alignment.topLeft,
                         end: Alignment.bottomRight,
                         colors: [
-                          accent.withOpacity(haloOpacity),
+                          accent.withOpacity(isDark ? 0.28 : 0.16),
                           Colors.transparent,
                         ],
                       ),
@@ -80,89 +95,157 @@ class NotificationCard extends StatelessWidget {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.fromLTRB(18, 20, 20, 18),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 18),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: accent.withOpacity(isDark ? 0.28 : 0.18),
-                        boxShadow: [
-                          BoxShadow(
-                            color: accent.withOpacity(isDark ? 0.35 : 0.3),
-                            blurRadius: 14,
-                            offset: const Offset(0, 8),
-                          ),
-                        ],
-                      ),
-                      child: Icon(
-                        Icons.notifications_active_rounded,
-                        color: isDark ? Colors.white : accent,
-                        size: 24,
-                      ),
-                    ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  message.title,
-                                  style: TextStyle(
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w700,
-                                    height: 1.25,
-                                    color: primaryTextColor,
-                                  ),
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Container(
+                          width: 48,
+                          height: 48,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            gradient: LinearGradient(
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                              colors: [
+                                accent.withOpacity(isDark ? 0.45 : 0.35),
+                                accent.withOpacity(isDark ? 0.22 : 0.18),
+                              ],
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: accent.withOpacity(isDark ? 0.4 : 0.25),
+                                blurRadius: 16,
+                                offset: const Offset(0, 8),
                               ),
-                              if (isUnread)
-                                Container(
-                                  margin: const EdgeInsets.only(left: 8),
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 10,
-                                    vertical: 4,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: accent.withOpacity(isDark ? 0.3 : 0.2),
-                                    borderRadius: BorderRadius.circular(999),
-                                  ),
-                                  child: Text(
-                                    'Mới',
-                                    style: TextStyle(
-                                      fontSize: 11,
-                                      fontWeight: FontWeight.w600,
-                                      letterSpacing: 0.3,
-                                      color: isDark ? Colors.white : accent,
-                                    ),
-                                  ),
-                                ),
                             ],
                           ),
-                          if (timestamp != null) ...[
-                            const SizedBox(height: 8),
+                          child: const Icon(
+                            Icons.notifications_active_rounded,
+                            color: Colors.white,
+                            size: 24,
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      title,
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.w700,
+                                        height: 1.25,
+                                        color: primaryTextColor,
+                                      ),
+                                      maxLines: 2,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                  if (isUnread)
+                                    Container(
+                                      margin: const EdgeInsets.only(left: 12),
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 4,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        borderRadius: BorderRadius.circular(999),
+                                        color: accent.withOpacity(
+                                            isDark ? 0.28 : 0.18),
+                                        border: Border.all(
+                                          color:
+                                              accent.withOpacity(isDark ? 0.65 : 0.45),
+                                          width: 0.8,
+                                        ),
+                                      ),
+                                      child: Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Icon(
+                                            Icons.fiber_manual_record,
+                                            size: 10,
+                                            color: isDark ? Colors.white : accent,
+                                          ),
+                                          const SizedBox(width: 6),
+                                          Text(
+                                            'Mới',
+                                            style: TextStyle(
+                                              fontSize: 11,
+                                              fontWeight: FontWeight.w600,
+                                              letterSpacing: 0.3,
+                                              color:
+                                                  isDark ? Colors.white : accent,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                ],
+                              ),
+                              if (hasBody) ...[
+                                const SizedBox(height: 10),
+                                Text(
+                                  bodyText,
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    height: 1.45,
+                                    color: secondaryTextColor,
+                                  ),
+                                  maxLines: 3,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    if (timestamp != null) ...[
+                      const SizedBox(height: 18),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
+                        decoration: BoxDecoration(
+                          color: isDark
+                              ? Colors.white.withOpacity(0.05)
+                              : const Color(0xFFEFF3FB),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.schedule_rounded,
+                              size: 18,
+                              color: secondaryTextColor
+                                  .withOpacity(isDark ? 0.8 : 0.7),
+                            ),
+                            const SizedBox(width: 6),
                             Text(
                               timestamp,
                               style: TextStyle(
                                 fontSize: 12,
-                                fontWeight: FontWeight.w500,
-                                color: secondaryTextColor,
+                                fontWeight: FontWeight.w600,
+                                letterSpacing: 0.2,
+                                color:
+                                    secondaryTextColor.withOpacity(isDark ? 0.95 : 0.9),
                               ),
                             ),
                           ],
-                        ],
+                        ),
                       ),
-                    ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/widget/notification/notification_card.dart
+++ b/lib/widget/notification/notification_card.dart
@@ -27,31 +27,20 @@ class NotificationCard extends StatelessWidget {
         ? GlobalColors.darkSecondaryText
         : GlobalColors.lightSecondaryText;
 
-    final Color baseCardColor =
-        isDark ? const Color(0xFF10192B) : Colors.white;
-    final Color unreadTint = accent.withOpacity(isDark ? 0.28 : 0.18);
-    final Color cardColor = isUnread
-        ? Color.lerp(baseCardColor, unreadTint, 0.6) ?? baseCardColor
-        : baseCardColor;
+    final Color cardColor = isDark ? const Color(0xFF131A2B) : Colors.white;
     final Color outlineColor = isUnread
-        ? accent.withOpacity(isDark ? 0.65 : 0.4)
-        : (isDark ? Colors.white.withOpacity(0.06) : const Color(0xFFE4E8F2));
-
-    final List<BoxShadow> shadows = [
-      BoxShadow(
-        color:
-            isDark ? Colors.black.withOpacity(0.55) : Colors.black.withOpacity(0.08),
-        blurRadius: 28,
-        offset: const Offset(0, 18),
-      ),
-      if (isUnread)
-        BoxShadow(
-          color: accent.withOpacity(isDark ? 0.4 : 0.26),
-          blurRadius: 36,
-          spreadRadius: 1,
-          offset: const Offset(0, 20),
-        ),
-    ];
+        ? accent.withOpacity(isDark ? 0.5 : 0.35)
+        : (isDark ? Colors.white.withOpacity(0.08) : const Color(0xFFE4E8F2));
+    final Color shadowColor =
+        isDark ? Colors.black.withOpacity(0.45) : const Color(0x14172133);
+    final Color iconBackgroundColor = isUnread
+        ? accent.withOpacity(isDark ? 0.24 : 0.15)
+        : (isDark ? Colors.white.withOpacity(0.06) : const Color(0xFFF2F5FB));
+    final Color badgeBackgroundColor =
+        accent.withOpacity(isDark ? 0.22 : 0.14);
+    final Color badgeTextColor = isDark ? Colors.white : accent;
+    final Color timestampBackgroundColor =
+        isDark ? Colors.white.withOpacity(0.03) : const Color(0xFFF5F7FC);
 
     final String title = message.title.trim().isNotEmpty
         ? message.title.trim()
@@ -63,39 +52,47 @@ class NotificationCard extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(20),
         onTap: onTap,
         child: Container(
           decoration: BoxDecoration(
             color: cardColor,
-            borderRadius: BorderRadius.circular(24),
+            borderRadius: BorderRadius.circular(20),
             border: Border.all(
               color: outlineColor,
-              width: isUnread ? 1.4 : 1,
+              width: 1,
             ),
-            boxShadow: shadows,
+            boxShadow: [
+              BoxShadow(
+                color: shadowColor,
+                blurRadius: 20,
+                offset: const Offset(0, 12),
+              ),
+            ],
           ),
           child: Stack(
             children: [
-              Positioned.fill(
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(24),
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors: [
-                          accent.withOpacity(isDark ? 0.28 : 0.16),
-                          Colors.transparent,
-                        ],
+              if (isUnread)
+                Positioned.fill(
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Container(
+                      width: 4,
+                      margin: const EdgeInsets.symmetric(vertical: 12),
+                      decoration: BoxDecoration(
+                        color: accent.withOpacity(isDark ? 0.85 : 0.7),
+                        borderRadius: BorderRadius.circular(12),
                       ),
                     ),
                   ),
                 ),
-              ),
               Padding(
-                padding: const EdgeInsets.fromLTRB(20, 20, 20, 18),
+                padding: EdgeInsets.fromLTRB(
+                  isUnread ? 28 : 20,
+                  18,
+                  20,
+                  18,
+                ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -103,33 +100,23 @@ class NotificationCard extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Container(
-                          width: 48,
-                          height: 48,
+                          width: 44,
+                          height: 44,
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
-                            gradient: LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors: [
-                                accent.withOpacity(isDark ? 0.45 : 0.35),
-                                accent.withOpacity(isDark ? 0.22 : 0.18),
-                              ],
+                            color: iconBackgroundColor,
+                            border: Border.all(
+                              color: accent.withOpacity(isDark ? 0.5 : 0.25),
+                              width: 1,
                             ),
-                            boxShadow: [
-                              BoxShadow(
-                                color: accent.withOpacity(isDark ? 0.4 : 0.25),
-                                blurRadius: 16,
-                                offset: const Offset(0, 8),
-                              ),
-                            ],
                           ),
-                          child: const Icon(
-                            Icons.notifications_active_rounded,
-                            color: Colors.white,
+                          child: Icon(
+                            Icons.notifications_none_rounded,
                             size: 24,
+                            color: accent,
                           ),
                         ),
-                        const SizedBox(width: 16),
+                        const SizedBox(width: 14),
                         Expanded(
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
@@ -141,9 +128,9 @@ class NotificationCard extends StatelessWidget {
                                     child: Text(
                                       title,
                                       style: TextStyle(
-                                        fontSize: 16,
+                                        fontSize: 15,
                                         fontWeight: FontWeight.w700,
-                                        height: 1.25,
+                                        height: 1.3,
                                         color: primaryTextColor,
                                       ),
                                       maxLines: 2,
@@ -152,52 +139,40 @@ class NotificationCard extends StatelessWidget {
                                   ),
                                   if (isUnread)
                                     Container(
-                                      margin: const EdgeInsets.only(left: 12),
+                                      margin: const EdgeInsets.only(left: 8),
                                       padding: const EdgeInsets.symmetric(
-                                        horizontal: 12,
+                                        horizontal: 10,
                                         vertical: 4,
                                       ),
                                       decoration: BoxDecoration(
                                         borderRadius: BorderRadius.circular(999),
-                                        color: accent.withOpacity(
-                                            isDark ? 0.28 : 0.18),
+                                        color: badgeBackgroundColor,
                                         border: Border.all(
-                                          color:
-                                              accent.withOpacity(isDark ? 0.65 : 0.45),
+                                          color: accent.withOpacity(
+                                            isDark ? 0.55 : 0.4,
+                                          ),
                                           width: 0.8,
                                         ),
                                       ),
-                                      child: Row(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Icon(
-                                            Icons.fiber_manual_record,
-                                            size: 10,
-                                            color: isDark ? Colors.white : accent,
-                                          ),
-                                          const SizedBox(width: 6),
-                                          Text(
-                                            'Mới',
-                                            style: TextStyle(
-                                              fontSize: 11,
-                                              fontWeight: FontWeight.w600,
-                                              letterSpacing: 0.3,
-                                              color:
-                                                  isDark ? Colors.white : accent,
-                                            ),
-                                          ),
-                                        ],
+                                      child: Text(
+                                        'Mới',
+                                        style: TextStyle(
+                                          fontSize: 11,
+                                          fontWeight: FontWeight.w600,
+                                          letterSpacing: 0.2,
+                                          color: badgeTextColor,
+                                        ),
                                       ),
                                     ),
                                 ],
                               ),
                               if (hasBody) ...[
-                                const SizedBox(height: 10),
+                                const SizedBox(height: 8),
                                 Text(
                                   bodyText,
                                   style: TextStyle(
                                     fontSize: 14,
-                                    height: 1.45,
+                                    height: 1.5,
                                     color: secondaryTextColor,
                                   ),
                                   maxLines: 3,
@@ -210,40 +185,45 @@ class NotificationCard extends StatelessWidget {
                       ],
                     ),
                     if (timestamp != null) ...[
-                      const SizedBox(height: 18),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 8,
-                        ),
-                        decoration: BoxDecoration(
-                          color: isDark
-                              ? Colors.white.withOpacity(0.05)
-                              : const Color(0xFFEFF3FB),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.schedule_rounded,
-                              size: 18,
-                              color: secondaryTextColor
-                                  .withOpacity(isDark ? 0.8 : 0.7),
+                      const SizedBox(height: 16),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 6,
                             ),
-                            const SizedBox(width: 6),
-                            Text(
-                              timestamp,
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                letterSpacing: 0.2,
-                                color:
-                                    secondaryTextColor.withOpacity(isDark ? 0.95 : 0.9),
-                              ),
+                            decoration: BoxDecoration(
+                              color: timestampBackgroundColor,
+                              borderRadius: BorderRadius.circular(999),
                             ),
-                          ],
-                        ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(
+                                  Icons.schedule_rounded,
+                                  size: 16,
+                                  color: secondaryTextColor.withOpacity(
+                                    isDark ? 0.85 : 0.7,
+                                  ),
+                                ),
+                                const SizedBox(width: 6),
+                                Text(
+                                  timestamp,
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                    letterSpacing: 0.2,
+                                    color: secondaryTextColor.withOpacity(
+                                      isDark ? 0.95 : 0.85,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ],


### PR DESCRIPTION
## Summary
- refresh the notification card styling with accent-driven surfaces and softer shadows for better readability
- show a compact body preview and timestamp capsule to make new notifications easier to scan

## Testing
- Not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ce1116f1cc832bbaae24ecea923ca0